### PR TITLE
Alterationx10/GitHub publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ project/project
 target
 *.log
 graal_dumps
+.idea
+metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,6 @@ scalacOptions ++= Seq(
   "-language:implicitConversions",
 )
 
-ThisBuild / githubOwner := "fwbrasil"
-ThisBuild / githubRepository := "kyo"
-ThisBuild / githubTokenSource := TokenSource.Environment("GITHUB_TOKEN")
-
 scalafmtOnCompile := true
 version := "0.1.0-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,40 +3,38 @@ val scala3Version = "3.2.0"
 fork in run := true
 
 scalacOptions ++= Seq(
-  "-encoding",
-  "utf8",
-  "-feature",
-  "-unchecked",
-  "-deprecation",
-  "-explain",
-  "-language:implicitConversions",
+    "-encoding",
+    "utf8",
+    "-feature",
+    "-unchecked",
+    "-deprecation",
+    "-explain",
+    "-language:implicitConversions"
 )
 
 scalafmtOnCompile := true
-version := "0.1.0-SNAPSHOT"
+version           := "0.1.0-SNAPSHOT"
 
 lazy val kyo = (project in file("."))
   .aggregate(`kyo-core`, `kyo-bench`, `kyo-zio`)
   .settings(
-    name := "kyo",
-    scalaVersion := scala3Version,
-    publishArtifact := false
+      name            := "kyo",
+      scalaVersion    := scala3Version,
+      publishArtifact := false
   )
 
 lazy val `kyo-core` = project
   .in(file("kyo-core"))
   .settings(
-    name := "kyo-core",
-    scalaVersion := scala3Version,
-    
-    libraryDependencies += "dev.zio" %% "izumi-reflect" % "2.2.2",
-
-    libraryDependencies += "dev.zio" %% "zio-test" % "2.0.3" % Test,
-    libraryDependencies += "dev.zio" %% "zio-test-magnolia" % "2.0.3" % Test,
-    libraryDependencies += "dev.zio" %% "zio-test-sbt" % "2.0.3" % Test,
-    libraryDependencies += "dev.zio" %% "zio-prelude" % "1.0.0-RC16" % Test,
-    libraryDependencies += "dev.zio" %% "zio-laws-laws" % "1.0.0-RC16" % Test,
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
+      name                                   := "kyo-core",
+      scalaVersion                           := scala3Version,
+      libraryDependencies += "dev.zio"       %% "izumi-reflect"     % "2.2.2",
+      libraryDependencies += "dev.zio"       %% "zio-test"          % "2.0.3"      % Test,
+      libraryDependencies += "dev.zio"       %% "zio-test-magnolia" % "2.0.3"      % Test,
+      libraryDependencies += "dev.zio"       %% "zio-test-sbt"      % "2.0.3"      % Test,
+      libraryDependencies += "dev.zio"       %% "zio-prelude"       % "1.0.0-RC16" % Test,
+      libraryDependencies += "dev.zio"       %% "zio-laws-laws"     % "1.0.0-RC16" % Test,
+      libraryDependencies += "org.scalatest" %% "scalatest"         % "3.2.11"     % Test
   )
 
 lazy val `kyo-bench` = project
@@ -44,21 +42,19 @@ lazy val `kyo-bench` = project
   .enablePlugins(JmhPlugin)
   .dependsOn(`kyo-core`)
   .settings(
-    name := "kyo-bench",
-    scalaVersion := scala3Version,
-    
-    libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.12",
-    libraryDependencies += "dev.zio" %% "zio" % "2.0.3",
+      name                                   := "kyo-bench",
+      scalaVersion                           := scala3Version,
+      libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.12",
+      libraryDependencies += "dev.zio"       %% "zio"         % "2.0.3"
   )
 
 lazy val `kyo-zio` = project
   .in(file("kyo-zio"))
   .dependsOn(`kyo-core`)
   .settings(
-    name := "kyo-zio",
-    scalaVersion := scala3Version,
-    
-    libraryDependencies += "dev.zio" %% "zio" % "2.0.3",
-  )  
+      name                             := "kyo-zio",
+      scalaVersion                     := scala3Version,
+      libraryDependencies += "dev.zio" %% "zio" % "2.0.3"
+  )
 
 testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,6 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.4")
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")


### PR DESCRIPTION
👋 Excited to play around with kyo!

I was greeted with an error loading the project. It seems to be because the `sbt-github-packages` requires a token source to exists, or else it will fail. There doesn't seem to be an option to tell it "Hey, I'm not the CI, I'd just like the run the project", which I've run into before, and perhaps not everyone likes to load up a system with dummy variables, so I tend to just not use it.

If interested, this PR sets up what you'd need to publish to GitHub without a plugin. There's also some code about setting the version published based off a tag/release, but could be removed if you just want to set it manually, or use something like sbt-dynver. ( If you want to keep it, I also tend to shove it in a seperate `.scala` file in  `project/` so it doesn't clutter up the main `build.sbt`)

I didn't add it, but here is a github action I've used with this code before:
```
name: Publish Artifact on Release
on:
  release:
    types: [ created ]
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
jobs:
  publish:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Set up JDK
        uses: actions/setup-java@v3
        with:
          distribution: 'temurin'
          java-version: '17'
          cache: 'sbt'
      - name: Publish
        run: sbt publish
```